### PR TITLE
Add support for non-instructors

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/scorestats/cli/CLI.java
+++ b/src/main/java/edu/kit/kastel/sdq/scorestats/cli/CLI.java
@@ -67,10 +67,13 @@ public class CLI {
 		courses.sort(Comparator.comparing(Course::getCourseId));
 
 		try (Scanner scanner = new Scanner(System.in)) {
-
-			OptionDialogue<Course> courseDialogue = new OptionDialogue<>(scanner, "Please select the course:",
+			Course course = courses.get(0);
+			// only prompt if there is more than one course to select from
+			if (courses.size() > 1) {
+				OptionDialogue<Course> courseDialogue = new OptionDialogue<>(scanner, "Please select the course:",
 					courses.stream().collect(Collectors.toMap(Course::getShortName, item -> item, (i1, i2) -> null, LinkedHashMap::new)));
-			Course course = courseDialogue.prompt();
+				course = courseDialogue.prompt();
+			}
 
 			List<Exercise> exercises;
 			try {

--- a/src/main/java/edu/kit/kastel/sdq/scorestats/core/client/Artemis4JArtemisClient.java
+++ b/src/main/java/edu/kit/kastel/sdq/scorestats/core/client/Artemis4JArtemisClient.java
@@ -3,6 +3,7 @@ package edu.kit.kastel.sdq.scorestats.core.client;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +14,7 @@ import edu.kit.kastel.sdq.artemis4j.api.artemis.Exercise;
 import edu.kit.kastel.sdq.artemis4j.api.artemis.assessment.Feedback;
 import edu.kit.kastel.sdq.artemis4j.api.artemis.assessment.Result;
 import edu.kit.kastel.sdq.artemis4j.api.artemis.assessment.Submission;
+import edu.kit.kastel.sdq.artemis4j.api.client.ISubmissionsArtemisClient;
 import edu.kit.kastel.sdq.artemis4j.api.grading.IAnnotation;
 import edu.kit.kastel.sdq.artemis4j.client.AssessmentArtemisClient;
 import edu.kit.kastel.sdq.artemis4j.client.RestClientManager;
@@ -26,7 +28,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * An {@link ArtemisClient} using artemis4j.
- * 
+ *
  * @author Moritz Hertler
  * @version 1.0
  */
@@ -51,8 +53,13 @@ public class Artemis4JArtemisClient<K> implements ArtemisClient<K> {
 	}
 
 	public Assessments<K> loadAssessments(Exercise exercise, ExerciseConfig config) throws ArtemisClientException {
+		ISubmissionsArtemisClient submissionsClient = this.client.getSubmissionArtemisClient();
 
-		List<Submission> submissions = this.client.getSubmissionArtemisClient().getSubmissions(exercise);
+		Collection<Submission> submissions = new ArrayList<>(submissionsClient.getSubmissions(exercise, 0, false));
+
+		if (exercise.hasSecondCorrectionRound()) {
+			submissions.addAll(submissionsClient.getSubmissions(exercise, 1, false));
+		}
 
 		AnnotationDeserializer deserializer = null;
 		if (config != null) {


### PR DESCRIPTION
This PR enables tutors to generate the stats and removes an unnecessary prompt.

The code has only been tested locally, because https://github.com/kit-sdq/artemis4j/commit/f45b9c9443a9944537c1c46adc9654ba6e74a960 has not been released yet.

There are some issues that I did address, but did not include, because I do not know what the best solution would be.

Locally it does not finish executing, because the `PrefixMatcher` throws an exception without any explanation
```java
	@Override
	public boolean matches(Feedback feedback) {
		if (feedback.getFeedbackType() == FeedbackType.MANUAL_UNREFERENCED || !feedback.isTest()) {
			throw new IllegalArgumentException();
		}
```
when it encounters the `Security Test` which does not have a `testCase` (therefore the tool thinks it  is not a test and crashes).

There are other tests that do not have a `testCase` as well.

A solution would be to change the code to
```java
	@Override
	public boolean matches(Feedback feedback) {
		if (feedback.getFeedbackType() == FeedbackType.MANUAL_UNREFERENCED) {
			throw new IllegalArgumentException();
		}

		return feedback.getTestName().startsWith(this.prefix);
	}
```
but I guess that does not solve the underlying issue.

Another issue is that the tool breaks with manual assessments that do not have any annotations (only client_data = []):
```
[main] ERROR edu.kit.kastel.sdq.artemis4j.api.artemis.assessment.Feedback - Could not get long feedback for feedback with id ... and result id ....
edu.kit.kastel.sdq.artemis4j.api.ArtemisClientException: Got response code 404 with message 
	at edu.kit.kastel.sdq.artemis4j.client.AbstractArtemisClient.throwIfStatusUnsuccessful(AbstractArtemisClient.java:132)
	at edu.kit.kastel.sdq.artemis4j.client.AbstractArtemisClient.call(AbstractArtemisClient.java:82)
	at edu.kit.kastel.sdq.artemis4j.client.AssessmentArtemisClient.getLongFeedback(AssessmentArtemisClient.java:170)
	at edu.kit.kastel.sdq.artemis4j.api.artemis.assessment.Feedback.init(Feedback.java:99)
	at edu.kit.kastel.sdq.scorestats.core.client.Artemis4JArtemisClient.lambda$loadAssessments$0(Artemis4JArtemisClient.java:76)
	at java.base/java.util.Arrays$ArrayList.forEach(Arrays.java:4305)
	at edu.kit.kastel.sdq.scorestats.core.client.Artemis4JArtemisClient.loadAssessments(Artemis4JArtemisClient.java:76)
	at edu.kit.kastel.sdq.scorestats.cli.CLI.run(CLI.java:139)
	at edu.kit.kastel.sdq.scorestats.Application.main(Application.java:9)
```
(solution would be to remove those feedbacks before calling init)