### PR TITLE
fix NPE on not executed tests

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/scorestats/core/assessment/FeedbackGroup.java
+++ b/src/main/java/edu/kit/kastel/sdq/scorestats/core/assessment/FeedbackGroup.java
@@ -41,7 +41,7 @@ public class FeedbackGroup {
             return false;
         }
 
-        if (feedback.getPositive()) {
+        if (feedback.getPositive() != null && feedback.getPositive()) {
             this.passedFeedbacks.add(feedback);
         } else {
             this.failedFeedbacks.add(feedback);


### PR DESCRIPTION
If an exercise is chosen which contains test cases that have not been executed, an NPE is thrown. I guess that in this case the object can't get properly created from json, resulting in the "positive" value being null.
![grafik](https://github.com/kit-sdq/programming-lecture-artemis-score-stats/assets/24572557/47c616f1-67ab-42a0-a11b-58337b34a384)

Test cases become not executable when a test name only changes in its case. 
![grafik](https://github.com/kit-sdq/programming-lecture-artemis-score-stats/assets/24572557/e94965c1-f7d4-4a23-8515-512c51b143a7)
